### PR TITLE
Enable exporting timezones from etcetera folder, since some of these …

### DIFF
--- a/vzic.c
+++ b/vzic.c
@@ -165,10 +165,14 @@ main				(int		 argc,
   convert_olson_file ("northamerica");
   convert_olson_file ("southamerica");
 
+  /*
+   * ical4j supports Etc/* timezones
+   */
+  convert_olson_file ("etcetera");
+
   /* These are backwards-compatability and weird stuff. */
 #if 0
   convert_olson_file ("backward");
-  convert_olson_file ("etcetera");
   convert_olson_file ("leapseconds");
   convert_olson_file ("pacificnew");
   convert_olson_file ("solar87");


### PR DESCRIPTION
…timezones are still in use in ical4j

hi Ben, 

It's just one line change to get the timezone ics from `etceter`. These ics files will be correctly exported under `Etc` folder. 

Hubert